### PR TITLE
Submit button validation optimization

### DIFF
--- a/scutranscript/staticfiles/js/transcript.js
+++ b/scutranscript/staticfiles/js/transcript.js
@@ -1,9 +1,15 @@
 $(document).ready(function() {
-    $('#paste_content').on('input', function(e) {
-        if (this.value.length > 0) {
-            $('input[type="submit"]').prop('disabled', false);
-        } else {
-            $('input[type="submit"]').prop('disabled', true);
-        }
-    });
+    //check validity on page load
+	validateSubmit();
+	
+	//listen for input editing to validate
+    $('#paste_content').on('input', validateSubmit);
 });
+
+function validateSubmit() {
+	if ($('#paste_content').val().length > 0) { 
+		$('input[type="submit"]').prop('disabled', false);
+	} else {
+		$('input[type="submit"]').prop('disabled', true);
+	}
+}

--- a/scutranscript/staticfiles/js/transcript.js
+++ b/scutranscript/staticfiles/js/transcript.js
@@ -1,9 +1,9 @@
 $(document).ready(function() {
-    //check validity on page load
+	//check validity on page load
 	validateSubmit();
 	
 	//listen for input editing to validate
-    $('#paste_content').on('input', validateSubmit);
+	$('#paste_content').on('input', validateSubmit);
 });
 
 function validateSubmit() {


### PR DESCRIPTION
`$('#paste_content').value.length` was changed to `$('#paste_content').val().length` since `.val()` wouldn't return `undefined` if the box was empty. Closes #2. 
